### PR TITLE
retrieve record name, record pair instead of just the record

### DIFF
--- a/lib/deepstream.rb
+++ b/lib/deepstream.rb
@@ -67,7 +67,7 @@ class Deepstream::List < Deepstream::Record
   end
 
   def all
-    @data.map { |x| @client.get(x) }
+    @data.map { |x| [x, @client.get(x)] }
   end
 
   def keys


### PR DESCRIPTION
the call to .all() didn't retrieve the names of the records. I think this may be more useful.
