### PR TITLE
read the initial connection ACK

### DIFF
--- a/lib/deepstream.rb
+++ b/lib/deepstream.rb
@@ -115,7 +115,8 @@ class Deepstream::Client
 
   def _login(credentials)
     _write("A", "REQ", credentials.to_json)
-    raise unless _read_socket == %w{A A}
+    ack = _read_socket
+    raise unless ack == %w{A A} || (ack == %w{C A} && _read_socket == %w{A A})
   end
 
   def _read_socket(timeout: nil)

--- a/lib/deepstream.rb
+++ b/lib/deepstream.rb
@@ -115,7 +115,7 @@ class Deepstream::Client
 
   def _login(credentials)
     _write("A", "REQ", credentials.to_json)
-    raise unless _read_socket == %w{A A}
+    raise unless _read_socket == %w{C A} && _read_socket == %w{A A}
   end
 
   def _read_socket(timeout: nil)


### PR DESCRIPTION
The client is broken for deepstream versions since https://github.com/deepstreamIO/deepstream.io/pull/124/commits/89f3a3031673395fc3045ea5bb5488344be9d38c commit.
